### PR TITLE
make the loadable regex work for minimized bundles

### DIFF
--- a/src/loadable.js
+++ b/src/loadable.js
@@ -8,8 +8,8 @@ const removeFromPending = promise => pending = pending.filter(a => a !== promise
 const trimImport = str => str.replace(/['"]/g, '');
 
 export const importMatch = functionString => {
-  const markMatches = functionString.match(/\(['"]imported-component['"],\s['"](.*),/g) || [];
-  return markMatches.map(match => trimImport(match.match(/\(['"]imported-component['"],\s['"]([^'"]*)['"],/i)[1]));
+  const markMatches = functionString.match(/\(['"]imported-component['"],\s?['"](.*),/g) || [];
+  return markMatches.map(match => trimImport(match.match(/\(['"]imported-component['"],\s?['"]([^'"]*)['"],/i)[1]));
 }
 
 const toLoadable = (importFunction, autoImport = true) => {


### PR DESCRIPTION
Unnecessary spaces are removed in minimized bundles, e.g., these generated by webpack in production mode. Update the regex to handle it.