### PR TITLE
fixing readme - section: comparison table legend

### DIFF
--- a/README.md
+++ b/README.md
@@ -754,6 +754,7 @@ state loss if `lazy` is created not in the user space. At it would be created in
 If React-Hot-Loader is detected `lazy` switches to `imported async` mode, this behaves absolutely the same. 
 
 <a name="comparisonLegend" />
+
 ### Comparison table legend
 - `Library` - the library name
 - `Suspense` - does it support Suspense feature


### PR DESCRIPTION
The current `README.md` looks like that:
![Captura de tela de 2019-10-03 22-09-57](https://user-images.githubusercontent.com/12635603/66174293-b4eda980-e62a-11e9-8ab1-fb88a3d7b111.png)

---

I just fixed it to this:
![Captura de tela de 2019-10-03 22-11-26](https://user-images.githubusercontent.com/12635603/66174314-c46cf280-e62a-11e9-8fc7-4f03c180f8d7.png)

Is it right?