### PR TITLE
fix: terser might compress different files differently, fixes #166

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+__tests__/__fixtures__

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -12,6 +12,6 @@ module.exports = [
   {
     path: 'dist/es2015/boot.js',
     ignore: ['tslib'],
-    limit: '1.7 KB',
+    limit: '1.8 KB',
   },
 ];

--- a/.size.json
+++ b/.size.json
@@ -2,16 +2,16 @@
   {
     "name": "dist/es2015/index.js, dist/es2015/boot.js",
     "passed": true,
-    "size": 3407
+    "size": 3426
   },
   {
     "name": "dist/es2015/index.js",
     "passed": true,
-    "size": 3123
+    "size": 3130
   },
   {
     "name": "dist/es2015/boot.js",
     "passed": true,
-    "size": 1695
+    "size": 1756
   }
 ]

--- a/.size.json
+++ b/.size.json
@@ -2,12 +2,12 @@
   {
     "name": "dist/es2015/index.js, dist/es2015/boot.js",
     "passed": true,
-    "size": 3426
+    "size": 3428
   },
   {
     "name": "dist/es2015/index.js",
     "passed": true,
-    "size": 3130
+    "size": 3133
   },
   {
     "name": "dist/es2015/boot.js",

--- a/__tests__/__fixtures__/babel/node/expected.js
+++ b/__tests__/__fixtures__/babel/node/expected.js
@@ -1,17 +1,71 @@
-var importedWrapper = function (marker, realImport) {
-  if (typeof __deoptimization_sideEffect__ !== 'undefined') {
-    __deoptimization_sideEffect__(marker, realImport);
+var importedWrapper = require('react-imported-component/wrapper');
+
+function _interopRequireWildcard(obj) {
+  if (obj && obj.__esModule) {
+    return obj;
+  } else {
+    var newObj = {};
+    if (obj != null) {
+      for (var key in obj) {
+        if (Object.prototype.hasOwnProperty.call(obj, key)) {
+          var desc =
+            Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {};
+          if (desc.get || desc.set) {
+            Object.defineProperty(newObj, key, desc);
+          } else {
+            newObj[key] = obj[key];
+          }
+        }
+      }
+    }
+    newObj.default = obj;
+    return newObj;
   }
-
-  return realImport;
-};
-
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
+}
 
 import imported from 'react-imported-component';
-const AsyncComponent0 = imported(() => importedWrapper("imported_18g2v0c_component", Promise.resolve().then(() => _interopRequireWildcard(require('./MyComponent')))));
-const AsyncComponent1 = imported(() => importedWrapper("imported_18g2v0c_component", Promise.resolve().then(() => _interopRequireWildcard(require('./MyComponent')))));
-const AsyncComponent2 = imported(async () => await importedWrapper("imported_18g2v0c_component", Promise.resolve().then(() => _interopRequireWildcard(require('./MyComponent')))));
-const AsyncComponent3 = imported(() => Promise.all([importedWrapper("imported_18g2v0c_component", Promise.resolve().then(() => _interopRequireWildcard(require('./MyComponent')))), importedWrapper("imported_18g2v0c_component", Promise.resolve().then(() => _interopRequireWildcard(require('./MyComponent'))))]));
-const AsyncComponent4 = imported(async () => (await Promise.all([importedWrapper("imported_-1qs8n90_component", Promise.resolve().then(() => _interopRequireWildcard(require('./MyComponent1')))), importedWrapper("imported_9j5sqq_component", Promise.resolve().then(() => _interopRequireWildcard(require('./MyComponent2'))))]))[0]);
+const AsyncComponent0 = imported(() =>
+  importedWrapper(
+    'imported_18g2v0c_component',
+    Promise.resolve().then(() => _interopRequireWildcard(require('./MyComponent')))
+  )
+);
+const AsyncComponent1 = imported(() =>
+  importedWrapper(
+    'imported_18g2v0c_component',
+    Promise.resolve().then(() => _interopRequireWildcard(require('./MyComponent')))
+  )
+);
+const AsyncComponent2 = imported(
+  async () =>
+    await importedWrapper(
+      'imported_18g2v0c_component',
+      Promise.resolve().then(() => _interopRequireWildcard(require('./MyComponent')))
+    )
+);
+const AsyncComponent3 = imported(() =>
+  Promise.all([
+    importedWrapper(
+      'imported_18g2v0c_component',
+      Promise.resolve().then(() => _interopRequireWildcard(require('./MyComponent')))
+    ),
+    importedWrapper(
+      'imported_18g2v0c_component',
+      Promise.resolve().then(() => _interopRequireWildcard(require('./MyComponent')))
+    ),
+  ])
+);
+const AsyncComponent4 = imported(
+  async () =>
+    (await Promise.all([
+      importedWrapper(
+        'imported_-1qs8n90_component',
+        Promise.resolve().then(() => _interopRequireWildcard(require('./MyComponent1')))
+      ),
+      importedWrapper(
+        'imported_9j5sqq_component',
+        Promise.resolve().then(() => _interopRequireWildcard(require('./MyComponent2')))
+      ),
+    ]))[0]
+);
 export default AsyncComponent1;

--- a/__tests__/__fixtures__/babel/node/expected.js
+++ b/__tests__/__fixtures__/babel/node/expected.js
@@ -1,71 +1,11 @@
 var importedWrapper = require('react-imported-component/wrapper');
 
-function _interopRequireWildcard(obj) {
-  if (obj && obj.__esModule) {
-    return obj;
-  } else {
-    var newObj = {};
-    if (obj != null) {
-      for (var key in obj) {
-        if (Object.prototype.hasOwnProperty.call(obj, key)) {
-          var desc =
-            Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {};
-          if (desc.get || desc.set) {
-            Object.defineProperty(newObj, key, desc);
-          } else {
-            newObj[key] = obj[key];
-          }
-        }
-      }
-    }
-    newObj.default = obj;
-    return newObj;
-  }
-}
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
 
 import imported from 'react-imported-component';
-const AsyncComponent0 = imported(() =>
-  importedWrapper(
-    'imported_18g2v0c_component',
-    Promise.resolve().then(() => _interopRequireWildcard(require('./MyComponent')))
-  )
-);
-const AsyncComponent1 = imported(() =>
-  importedWrapper(
-    'imported_18g2v0c_component',
-    Promise.resolve().then(() => _interopRequireWildcard(require('./MyComponent')))
-  )
-);
-const AsyncComponent2 = imported(
-  async () =>
-    await importedWrapper(
-      'imported_18g2v0c_component',
-      Promise.resolve().then(() => _interopRequireWildcard(require('./MyComponent')))
-    )
-);
-const AsyncComponent3 = imported(() =>
-  Promise.all([
-    importedWrapper(
-      'imported_18g2v0c_component',
-      Promise.resolve().then(() => _interopRequireWildcard(require('./MyComponent')))
-    ),
-    importedWrapper(
-      'imported_18g2v0c_component',
-      Promise.resolve().then(() => _interopRequireWildcard(require('./MyComponent')))
-    ),
-  ])
-);
-const AsyncComponent4 = imported(
-  async () =>
-    (await Promise.all([
-      importedWrapper(
-        'imported_-1qs8n90_component',
-        Promise.resolve().then(() => _interopRequireWildcard(require('./MyComponent1')))
-      ),
-      importedWrapper(
-        'imported_9j5sqq_component',
-        Promise.resolve().then(() => _interopRequireWildcard(require('./MyComponent2')))
-      ),
-    ]))[0]
-);
+const AsyncComponent0 = imported(() => importedWrapper("imported_18g2v0c_component", Promise.resolve().then(() => _interopRequireWildcard(require('./MyComponent')))));
+const AsyncComponent1 = imported(() => importedWrapper("imported_18g2v0c_component", Promise.resolve().then(() => _interopRequireWildcard(require('./MyComponent')))));
+const AsyncComponent2 = imported(async () => await importedWrapper("imported_18g2v0c_component", Promise.resolve().then(() => _interopRequireWildcard(require('./MyComponent')))));
+const AsyncComponent3 = imported(() => Promise.all([importedWrapper("imported_18g2v0c_component", Promise.resolve().then(() => _interopRequireWildcard(require('./MyComponent')))), importedWrapper("imported_18g2v0c_component", Promise.resolve().then(() => _interopRequireWildcard(require('./MyComponent'))))]));
+const AsyncComponent4 = imported(async () => (await Promise.all([importedWrapper("imported_-1qs8n90_component", Promise.resolve().then(() => _interopRequireWildcard(require('./MyComponent1')))), importedWrapper("imported_9j5sqq_component", Promise.resolve().then(() => _interopRequireWildcard(require('./MyComponent2'))))]))[0]);
 export default AsyncComponent1;

--- a/__tests__/__fixtures__/babel/webpack/expected.js
+++ b/__tests__/__fixtures__/babel/webpack/expected.js
@@ -1,19 +1,32 @@
-var importedWrapper = function (marker, realImport) {
-  if (typeof __deoptimization_sideEffect__ !== 'undefined') {
-    __deoptimization_sideEffect__(marker, realImport);
-  }
+var importedWrapper = require('react-imported-component/wrapper');
 
-  return realImport;
-};
-
-import { lazy, useImported } from "react-imported-component";
-import { assignImportedComponents } from "react-imported-component/boot";
+import { lazy, useImported } from 'react-imported-component';
+import { assignImportedComponents } from 'react-imported-component/boot';
 import imported from 'react-imported-component';
-const AsyncComponent0 = imported(() => importedWrapper("imported_18g2v0c_component", import(
-/* webpackChunkName:namedChunk */
-'./MyComponent')));
-const AsyncComponent1 = imported(() => importedWrapper("imported_18g2v0c_component", import('./MyComponent')));
-const AsyncComponent2 = imported(async () => await importedWrapper("imported_18g2v0c_component", import('./MyComponent')));
-const AsyncComponent3 = imported(() => Promise.all([importedWrapper("imported_18g2v0c_component", import('./MyComponent')), importedWrapper("imported_18g2v0c_component", import('./MyComponent'))]));
-const AsyncComponent4 = imported(async () => (await Promise.all([importedWrapper("imported_-1qs8n90_component", import('./MyComponent1')), importedWrapper("imported_9j5sqq_component", import('./MyComponent2'))]))[0]);
+const AsyncComponent0 = imported(() =>
+  importedWrapper(
+    'imported_18g2v0c_component',
+    import(
+      /* webpackChunkName:namedChunk */
+      './MyComponent'
+    )
+  )
+);
+const AsyncComponent1 = imported(() => importedWrapper('imported_18g2v0c_component', import('./MyComponent')));
+const AsyncComponent2 = imported(
+  async () => await importedWrapper('imported_18g2v0c_component', import('./MyComponent'))
+);
+const AsyncComponent3 = imported(() =>
+  Promise.all([
+    importedWrapper('imported_18g2v0c_component', import('./MyComponent')),
+    importedWrapper('imported_18g2v0c_component', import('./MyComponent')),
+  ])
+);
+const AsyncComponent4 = imported(
+  async () =>
+    (await Promise.all([
+      importedWrapper('imported_-1qs8n90_component', import('./MyComponent1')),
+      importedWrapper('imported_9j5sqq_component', import('./MyComponent2')),
+    ]))[0]
+);
 export default AsyncComponent1;

--- a/__tests__/__fixtures__/babel/webpack/expected.js
+++ b/__tests__/__fixtures__/babel/webpack/expected.js
@@ -1,32 +1,13 @@
 var importedWrapper = require('react-imported-component/wrapper');
 
-import { lazy, useImported } from 'react-imported-component';
-import { assignImportedComponents } from 'react-imported-component/boot';
+import { lazy, useImported } from "react-imported-component";
+import { assignImportedComponents } from "react-imported-component/boot";
 import imported from 'react-imported-component';
-const AsyncComponent0 = imported(() =>
-  importedWrapper(
-    'imported_18g2v0c_component',
-    import(
-      /* webpackChunkName:namedChunk */
-      './MyComponent'
-    )
-  )
-);
-const AsyncComponent1 = imported(() => importedWrapper('imported_18g2v0c_component', import('./MyComponent')));
-const AsyncComponent2 = imported(
-  async () => await importedWrapper('imported_18g2v0c_component', import('./MyComponent'))
-);
-const AsyncComponent3 = imported(() =>
-  Promise.all([
-    importedWrapper('imported_18g2v0c_component', import('./MyComponent')),
-    importedWrapper('imported_18g2v0c_component', import('./MyComponent')),
-  ])
-);
-const AsyncComponent4 = imported(
-  async () =>
-    (await Promise.all([
-      importedWrapper('imported_-1qs8n90_component', import('./MyComponent1')),
-      importedWrapper('imported_9j5sqq_component', import('./MyComponent2')),
-    ]))[0]
-);
+const AsyncComponent0 = imported(() => importedWrapper("imported_18g2v0c_component", import(
+/* webpackChunkName:namedChunk */
+'./MyComponent')));
+const AsyncComponent1 = imported(() => importedWrapper("imported_18g2v0c_component", import('./MyComponent')));
+const AsyncComponent2 = imported(async () => await importedWrapper("imported_18g2v0c_component", import('./MyComponent')));
+const AsyncComponent3 = imported(() => Promise.all([importedWrapper("imported_18g2v0c_component", import('./MyComponent')), importedWrapper("imported_18g2v0c_component", import('./MyComponent'))]));
+const AsyncComponent4 = imported(async () => (await Promise.all([importedWrapper("imported_-1qs8n90_component", import('./MyComponent1')), importedWrapper("imported_9j5sqq_component", import('./MyComponent2'))]))[0]);
 export default AsyncComponent1;

--- a/__tests__/__snapshots__/macro.spec.ts.snap
+++ b/__tests__/__snapshots__/macro.spec.ts.snap
@@ -33,13 +33,7 @@ function _interopRequireWildcard(obj) {
   }
 }
 
-var importedWrapper = function(marker, realImport) {
-  if (typeof __deoptimization_sideEffect__ !== \\"undefined\\") {
-    __deoptimization_sideEffect__(marker, realImport);
-  }
-
-  return realImport;
-};
+var importedWrapper = require(\\"react-imported-component/wrapper\\");
 
 import { lazy } from \\"react-imported-component\\";
 import { assignImportedComponents } from \\"react-imported-component/boot\\";
@@ -92,13 +86,7 @@ function _interopRequireWildcard(obj) {
   }
 }
 
-var importedWrapper = function(marker, realImport) {
-  if (typeof __deoptimization_sideEffect__ !== \\"undefined\\") {
-    __deoptimization_sideEffect__(marker, realImport);
-  }
-
-  return realImport;
-};
+var importedWrapper = require(\\"react-imported-component/wrapper\\");
 
 importedWrapper(
   \\"imported_-1ko6oiq_component\\",
@@ -140,13 +128,7 @@ function _interopRequireWildcard(obj) {
   }
 }
 
-var importedWrapper = function(marker, realImport) {
-  if (typeof __deoptimization_sideEffect__ !== \\"undefined\\") {
-    __deoptimization_sideEffect__(marker, realImport);
-  }
-
-  return realImport;
-};
+var importedWrapper = require(\\"react-imported-component/wrapper\\");
 
 import { lazy } from \\"react-imported-component\\";
 const v = lazy(() =>
@@ -192,13 +174,7 @@ function _interopRequireWildcard(obj) {
   }
 }
 
-var importedWrapper = function(marker, realImport) {
-  if (typeof __deoptimization_sideEffect__ !== \\"undefined\\") {
-    __deoptimization_sideEffect__(marker, realImport);
-  }
-
-  return realImport;
-};
+var importedWrapper = require(\\"react-imported-component/wrapper\\");
 
 import { imported, useImported } from \\"react-imported-component\\";
 const v = imported(() =>
@@ -249,13 +225,7 @@ const x = () => useImported(() => import('./b'));
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var importedWrapper = function(marker, realImport) {
-  if (typeof __deoptimization_sideEffect__ !== \\"undefined\\") {
-    __deoptimization_sideEffect__(marker, realImport);
-  }
-
-  return realImport;
-};
+var importedWrapper = require(\\"react-imported-component/wrapper\\");
 
 function _interopRequireWildcard(obj) {
   if (obj && obj.__esModule) {
@@ -282,13 +252,7 @@ function _interopRequireWildcard(obj) {
   }
 }
 
-var importedWrapper = function(marker, realImport) {
-  if (typeof __deoptimization_sideEffect__ !== \\"undefined\\") {
-    __deoptimization_sideEffect__(marker, realImport);
-  }
-
-  return realImport;
-};
+var importedWrapper = require(\\"react-imported-component/wrapper\\");
 
 import { imported, useImported } from \\"react-imported-component\\";
 const v = imported(() =>

--- a/__tests__/loadable.spec.ts
+++ b/__tests__/loadable.spec.ts
@@ -1,4 +1,4 @@
-import {getFunctionSignature, getLoadable, importMatch} from "../src/loadable";
+import { getLoadable } from '../src/loadable';
 
 describe('getLoadable', () => {
   const importedWrapper = (_: any, b: any) => b;
@@ -7,61 +7,13 @@ describe('getLoadable', () => {
     const l1 = getLoadable(() => importedWrapper('imported_mark1_component', Promise.resolve(42)));
     const l2 = getLoadable(() => importedWrapper('imported_mark1_component', Promise.resolve(42)));
 
-    expect(l1).toEqual(l2)
+    expect(l1).toEqual(l2);
   });
 
   it('cache test - no mark present', () => {
     const l1 = getLoadable(() => Promise.resolve(42));
     const l2 = getLoadable(() => Promise.resolve(42));
 
-    expect(l1).not.toEqual(l2)
+    expect(l1).not.toEqual(l2);
   });
-});
-
-describe('importMatch', () => {
-  it('standard', () => {
-    expect(
-      importMatch(getFunctionSignature(`() => importedWrapper('imported_mark1_component', Promise.resolve(TargetComponent)), true)`))
-    ).toEqual(['mark1']);
-  });
-
-  it('webpack', () => {
-    expect(
-      importMatch(getFunctionSignature(`() => importedWrapper("imported_mark1_component", __webpack_require__.e(/*! import() */ 0).then(__webpack_require__.bind(null, /*! ./components/Another */ "./app/components/Another.tsx")))`))
-    ).toEqual(['mark1']);
-  });
-
-  it('webpack-prod', () => {
-    expect(
-      importMatch(getFunctionSignature(`() => importedWrapper('imported_mark1_component',__webpack_require__.e(/*! import() */ 0).then(__webpack_require__.bind(null, /*! ./components/Another */ "./app/components/Another.tsx")))`))
-    ).toEqual(['mark1']);
-  });
-
-  it('functional', () => {
-    expect(importMatch(getFunctionSignature(`"function loadable() {
-        return importedWrapper('imported_1ubbetg_component', __webpack_require__.e(/*! import() | namedChunk-1 */ "namedChunk-1").then(__webpack_require__.t.bind(null, /*! ./DeferredRender */ "./src/DeferredRender.js", 7)));
-      }"`))).toEqual(['1ubbetg']);
-  });
-
-  it('parcel', () => {
-    expect(importMatch(getFunctionSignature(`function _() {
-        return importedWrapper('imported_mark1_component', require("_bundle_loader")(require.resolve('./HelloWorld3')));
-    }`))).toEqual(['mark1']);
-  });
-
-  it('ie11 uglify', () => {
-    expect(importMatch(getFunctionSignature(`function _() {
-        var t = 'imported_mark1_component';
-    }`))).toEqual(['mark1']);
-  });
-
-  it('multiple imports in one line', () => {
-    expect(importMatch(getFunctionSignature(`function _() {
-        "imported_1pn9k36_component", blablabla- importedWrapper("imported_-1556gns_component")
-    }`))).toEqual(['1pn9k36', '-1556gns']);
-  });
-
-  it('maps function signatures', () => {
-    expect(getFunctionSignature(`import('file')`)).toEqual(getFunctionSignature(`import(/* */'file')`))
-  })
 });

--- a/__tests__/signatures.spec.ts
+++ b/__tests__/signatures.spec.ts
@@ -1,0 +1,92 @@
+import { getFunctionSignature, importMatch } from '../src/signatures';
+
+describe('signatures', () => {
+  const a = (i: any) => i;
+  const b = (i: any) => i;
+
+  it('extract markers from function', () => {
+    expect(importMatch(getFunctionSignature(() => a('imported_XXYY_component')))).toEqual(['XXYY']);
+  });
+
+  it('work similar for similar functions', () => {
+    expect(getFunctionSignature(() => a('imported_XXYY_component'))).toBe(
+      getFunctionSignature(() => b('imported_XXYY_component'))
+    );
+  });
+});
+
+describe('importMatch', () => {
+  it('standard', () => {
+    expect(
+      importMatch(
+        getFunctionSignature(
+          `() => importedWrapper('imported_mark1_component', Promise.resolve(TargetComponent)), true)`
+        )
+      )
+    ).toEqual(['mark1']);
+  });
+
+  it('webpack', () => {
+    expect(
+      importMatch(
+        getFunctionSignature(
+          `() => importedWrapper("imported_mark1_component", __webpack_require__.e(/*! import() */ 0).then(__webpack_require__.bind(null, /*! ./components/Another */ "./app/components/Another.tsx")))`
+        )
+      )
+    ).toEqual(['mark1']);
+  });
+
+  it('webpack-prod', () => {
+    expect(
+      importMatch(
+        getFunctionSignature(
+          `() => importedWrapper('imported_mark1_component',__webpack_require__.e(/*! import() */ 0).then(__webpack_require__.bind(null, /*! ./components/Another */ "./app/components/Another.tsx")))`
+        )
+      )
+    ).toEqual(['mark1']);
+  });
+
+  it('functional', () => {
+    expect(
+      importMatch(
+        getFunctionSignature(`"function loadable() {
+        return importedWrapper('imported_1ubbetg_component', __webpack_require__.e(/*! import() | namedChunk-1 */ "namedChunk-1").then(__webpack_require__.t.bind(null, /*! ./DeferredRender */ "./src/DeferredRender.js", 7)));
+      }"`)
+      )
+    ).toEqual(['1ubbetg']);
+  });
+
+  it('parcel', () => {
+    expect(
+      importMatch(
+        getFunctionSignature(`function _() {
+        return importedWrapper('imported_mark1_component', require("_bundle_loader")(require.resolve('./HelloWorld3')));
+    }`)
+      )
+    ).toEqual(['mark1']);
+  });
+
+  it('ie11 uglify', () => {
+    expect(
+      importMatch(
+        getFunctionSignature(`function _() {
+        var t = 'imported_mark1_component';
+    }`)
+      )
+    ).toEqual(['mark1']);
+  });
+
+  it('multiple imports in one line', () => {
+    expect(
+      importMatch(
+        getFunctionSignature(`function _() {
+        "imported_1pn9k36_component", blablabla- importedWrapper("imported_-1556gns_component")
+    }`)
+      )
+    ).toEqual(['1pn9k36', '-1556gns']);
+  });
+
+  it('maps function signatures', () => {
+    expect(getFunctionSignature(`import('file')`)).toEqual(getFunctionSignature(`import(/* */'file')`));
+  });
+});

--- a/__tests__/useImported.spec.tsx
+++ b/__tests__/useImported.spec.tsx
@@ -146,7 +146,7 @@ describe('useImported', () => {
 
     expect(wrapper.update().html()).toContain('nothing');
     wrapper.setProps({ loadit: true });
-    expect(wrapper.update().html()).toContain('nothing');
+    expect(wrapper.update().html()).toContain('loading');
 
     await act(async () => {
       await done();

--- a/__tests__/useImported.spec.tsx
+++ b/__tests__/useImported.spec.tsx
@@ -155,4 +155,32 @@ describe('useImported', () => {
     expect(wrapper.update().html()).toContain('loaded!');
     expect(drainHydrateMarks()).toEqual(['conditional-mark']);
   });
+
+  it('cached import', async () => {
+    // this test is not working as it should (it should be broken)
+    const importer = () => () => <span>loaded!</span>;
+
+    const Comp = () => {
+      const { loading, imported: Component } = useImported(importer as any);
+
+      if (Component) {
+        return <Component />;
+      }
+
+      if (loading) {
+        return <span>loading</span>;
+      }
+      return <span>nothing</span>;
+    };
+
+    const wrapper = mount(<Comp />);
+    expect(wrapper.html()).toContain('loading');
+    expect(wrapper.update().html()).toContain('loading');
+
+    await act(async () => {
+      await done();
+    });
+
+    expect(wrapper.update().html()).toContain('loaded!');
+  });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-imported-component",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "description": "I will import your component, and help to handle it",
   "main": "dist/es5/index.js",
   "jsnext:main": "dist/es2015/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-imported-component",
-  "version": "6.2.3",
+  "version": "6.2.4",
   "description": "I will import your component, and help to handle it",
   "main": "dist/es5/index.js",
   "jsnext:main": "dist/es2015/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-imported-component",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "description": "I will import your component, and help to handle it",
   "main": "dist/es5/index.js",
   "jsnext:main": "dist/es2015/index.js",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
     "boot",
     "server",
     "macro",
-    "babel.js"
+    "babel.js",
+    "wrapper.js"
   ],
   "husky": {
     "hooks": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import {isBackend} from "./detectBackend";
+import { isBackend } from './detectBackend';
 
 const rejectNetwork = (url: string) => url.indexOf('http') !== 0;
 
@@ -7,7 +7,7 @@ export const settings = {
   SSR: isBackend,
   rethrowErrors: process.env.NODE_ENV !== 'production',
   fileFilter: rejectNetwork,
-  updateOnReload: false,
+  updateOnReload: true,
 };
 
 export const setConfiguration = (config: Partial<typeof settings>) => {

--- a/src/signatures.ts
+++ b/src/signatures.ts
@@ -1,0 +1,14 @@
+import { AnyFunction, Mark } from './types';
+
+const trimImport = (str: string) => str.replace(/['"]/g, '');
+
+export const importMatch = (functionString: string): Mark => {
+  const markMatches = functionString.match(/`imported_(.*?)_component`/g) || [];
+  return markMatches.map(match => match && trimImport((match.match(/`imported_(.*?)_component`/i) || [])[1]));
+};
+
+export const getFunctionSignature = (fn: AnyFunction | string) =>
+  String(fn)
+    .replace(/(["'])/g, '`')
+    .replace(/\/\*([^\*]*)\*\//gi, '')
+    .replace(/([A-z0-9_]+)\(`imported_/g, '$(`imported_');

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,27 +1,28 @@
-import {ComponentType, ForwardRefExoticComponent, Ref, ReactElement, ReactNode} from "react";
+import { ComponentType, ForwardRefExoticComponent, ReactElement, ReactNode, Ref } from 'react';
 
 export interface DefaultImportedComponent<P> {
   default: ComponentType<P>;
 }
 
+export type AnyFunction = (x: any) => any;
+
 export interface Default<T> {
   default: T;
 }
 
-export type Stream = {
-  marks: Record<any,any>
-};
+export interface Stream {
+  marks: Record<any, any>;
+}
 
 export type Mark = string[];
 
 export type Promised<T> = () => Promise<T>;
 
 export type DefaultComponent<P> = ComponentType<P> | DefaultImportedComponent<P>;
-export type DefaultComponentImport<T> = () => Promise<DefaultComponent<T>>
-
+export type DefaultComponentImport<T> = () => Promise<DefaultComponent<T>>;
 
 export type Defaultable<P> = P | Default<P>;
-export type DefaultImport<T> = () => Promise<Defaultable<T>>
+export type DefaultImport<T> = () => Promise<Defaultable<T>>;
 
 export interface MarkMeta {
   loadable: Loadable<any>;
@@ -30,9 +31,9 @@ export interface MarkMeta {
   fileName: string;
 }
 
-export type LazyImport<T> = () => Promise<DefaultImportedComponent<T>>
+export type LazyImport<T> = () => Promise<DefaultImportedComponent<T>>;
 
-export type LoadableComponentState = {
+export interface LoadableComponentState {
   loading?: boolean;
   error?: any;
 }
@@ -61,14 +62,13 @@ export interface Loadable<T> {
   then(callback: (x: T) => void, err: () => void): Promise<any>;
 }
 
+export interface ComponentOptions<P, K> {
+  loadable: DefaultComponentImport<P> | Loadable<ComponentType<P>>;
 
-export type ComponentOptions<P, K> = {
-  loadable: DefaultComponentImport<P> | Loadable<ComponentType<P>>,
+  LoadingComponent?: ComponentType<any>;
+  ErrorComponent?: ComponentType<any>;
 
-  LoadingComponent?: ComponentType<any>,
-  ErrorComponent?: ComponentType<any>,
-
-  onError?: (a: any) => void,
+  onError?: (a: any) => void;
 
   async?: boolean;
 
@@ -78,27 +78,25 @@ export type ComponentOptions<P, K> = {
   forwardProps?: K;
 }
 
-export type HOCOptions = {
+export interface HOCOptions {
   noAutoImport?: boolean;
 }
 
-export type AdditionalHOC = {
-  preload(): Promise<void>;
+export interface AdditionalHOC {
   done: Promise<void>;
+  preload(): Promise<void>;
 }
 
-export type HOCType<P, K> =
-  ForwardRefExoticComponent<K & { importedProps?: Partial<ComponentOptions<P, K>> }> &
+export type HOCType<P, K> = ForwardRefExoticComponent<K & { importedProps?: Partial<ComponentOptions<P, K>> }> &
   AdditionalHOC;
 
 export interface ImportModuleHOCProps {
-  fallback: NonNullable<ReactNode>|null;
+  fallback: NonNullable<ReactNode> | null;
 }
 
 export interface ImportModuleProps<T> extends ImportModuleHOCProps {
   children: (arg: T) => ReactElement | null;
 }
-
 
 export interface FullImportModuleProps<T> extends ImportModuleProps<T> {
   import: DefaultImport<T> | Loadable<T>;
@@ -106,14 +104,9 @@ export interface FullImportModuleProps<T> extends ImportModuleProps<T> {
 
 export type ModuleFC<T> = (props: ImportModuleProps<T>) => ReactElement | null;
 
-export type HOCModuleType<T> =
-  ModuleFC<T> &
-  AdditionalHOC;
+export type HOCModuleType<T> = ModuleFC<T> & AdditionalHOC;
 
-
-export interface HOC {
-  <P, K = P>(loader: DefaultComponentImport<P>, options?: Partial<ComponentOptions<P, K>> & HOCOptions): HOCType<P, K>;
-}
+export type HOC = <P, K = P>(loader: DefaultComponentImport<P>, options?: Partial<ComponentOptions<P, K>> & HOCOptions) => HOCType<P, K>;
 
 export interface ImportedComponents {
   [index: number]: () => Promise<DefaultComponent<any>>;

--- a/src/useImported.ts
+++ b/src/useImported.ts
@@ -42,13 +42,15 @@ export function useLoadable<T>(loadable: Loadable<T>, options: HookOptions = {})
     return {};
   });
 
+  const wasDone = loadable.done;
+
   useEffect(() => {
     if (options.import !== false) {
       if (options.track !== false) {
         useMark(UID, loadable.mark);
       }
       // on the clientside it might be already loaded
-      if (!loadable.done) {
+      if (!wasDone) {
         loadLoadable(loadable, forceUpdate);
       }
     }

--- a/src/useImported.ts
+++ b/src/useImported.ts
@@ -47,7 +47,10 @@ export function useLoadable<T>(loadable: Loadable<T>, options: HookOptions = {})
       if (options.track !== false) {
         useMark(UID, loadable.mark);
       }
-      loadLoadable(loadable, forceUpdate);
+      // on the clientside it might be already loaded
+      if (!loadable.done) {
+        loadLoadable(loadable, forceUpdate);
+      }
     }
   }, [loadable, options.import]);
 

--- a/wrapper.js
+++ b/wrapper.js
@@ -1,0 +1,8 @@
+var importedWrapper = function(marker, realImport) {
+  if (typeof __deoptimization_sideEffect__ !== 'undefined') {
+    __deoptimization_sideEffect__(marker, realImport);
+  }
+  return realImport;
+};
+
+module.exports = importedWrapper;


### PR DESCRIPTION
Problem: If file contains only one `imported` signature then `importedWrapper` could be inlined into that single use case. As a result the code in the file, and the code in `async-imports` would be different.

The fix: more `importedWrapper` to `react-imported-component/wrapper`

----

Problem: `terser` optimization might mangle `importedWrapper`(no matter how it's defined) differently. As a result the code in the file, and the code in `async-imports` would be different.

The fix: `signature` would replace any `XXX("imported_` to the same result, making usage cases "the same". 