### PR TITLE
feat: supports overriding babel import names

### DIFF
--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -86,6 +86,39 @@ export interface ImportedConfiguration {
    * clientside configuration properties to be passed into `setConfiguration`
    */
   configuration?: Partial<ImportedClientSettings>;
+
+  /**
+   * Allowing for module name overrides, helpful for when you re-export wrappers.
+   */
+  modules?: {
+    /**
+     * The root module name
+     * 
+     * @default "react-imported-component"
+     */
+    native?: string;
+
+    /**
+     * The imported wrapper module name.
+     * 
+     * @default "react-imported-component/wrapper"
+     */
+    wrapper?: string;
+
+    /**
+     * When using the macro pathways.
+     * 
+     * @defaults "react-imported-component/macro"
+     */
+    macro?: string;
+
+    /**
+     * The module to ues during boot.
+     * 
+     * @defaults "react-imported-component/boot"
+     */
+    boot?: string;
+  }
 }
 
 /**


### PR DESCRIPTION
Sometimes in larger projects, `imported` is shared no through the package itself, but rather a monorepo re-export. 

This PR allows the babel plugin to have some of its import statements overriden to that of a config file.

One would think it shouldn't matter, but when dependencies are not hoisted, a target file might not have its `react-imported-components` realised. 