### PR TITLE
fix: Add guard for undefined global module

### DIFF
--- a/src/ui/HOC.tsx
+++ b/src/ui/HOC.tsx
@@ -73,7 +73,7 @@ export function lazy<T>(importer: LazyImport<T>): React.FC<T> {
 
   if (process.env.NODE_ENV !== 'production') {
     // lazy is not hot-reloadable
-    if ((module as any).hot) {
+    if (typeof module !== 'undefined' && (module as any)?.hot) {
       return loader(importer, { async: true });
     }
   }


### PR DESCRIPTION
Based on bundler (Vite for example), module might be undefined, I've added a guard to fix this problem.

Error example:
```
Uncaught ReferenceError: module is not defined
```